### PR TITLE
Bundle the license file in the .tar and .wheel packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ setup(
     keywords='doctest documentation test testing',
 
     packages=['byexample', 'byexample.modules'],
+    data_files=[("", ["LICENSE"])],
 
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
The license file was missing from the 'release' files (both, source
.tar.gz and 'binaries' .whl).
Closes #89