### PR TITLE
Force 'fork' as the multiprocessing start method

### DIFF
--- a/byexample/byexample.py
+++ b/byexample/byexample.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-import os, sys
+import os, sys, multiprocessing
 
 if sys.version_info < (3, 0):
     print(
@@ -32,6 +32,14 @@ def execute_examples(filename, sigint_handler):
 
 def main(args=None):
     global cache, harvester, executor, options, dry
+
+    # byexample relays on UNIX's fork to pass data from the
+    # parent process (us) to its children (Job's). Due the
+    # complexity of the objects passed, pickle cannot be used
+    # to serialize them so other start methods ('spawn', 'forkserver')
+    # cannot be used
+    # see https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+    multiprocessing.set_start_method('fork')
 
     init_log_system()
 


### PR DESCRIPTION
'fork' is the default in Unix and it was the default for macOS until
Python 3.8.

With this start method, objects from the parent are copied bit-by-bit
into the subprocesses' memory so they are an identical copy of its
parent.

The other methods available are 'spawn' and 'forkserver' that requires a
serialization of these objects using pickle.

Unfortunately these objects are quite complex and contain
non-serializable attributes so 'fork' is the only method available.

Note: the macOS support is still a little fragile: we use 'fork' so
byexample will work in Python 3.8 but the 'fork' in macOS has some
esoteric problems including crashes. It is a limitation of the OS and
the provided library, not of Python or byexample.

See https://bugs.python.org/issue33725