### PR TITLE
Issue #129: log shutdown failures and call terminate not matter what

### DIFF
--- a/byexample/runner.py
+++ b/byexample/runner.py
@@ -269,9 +269,33 @@ class PexpectMixin(object):
     @profile
     def _shutdown_interpreter(self):
         self._interpreter.sendeof()
-        self._interpreter.close()
+        try:
+            self._interpreter.close()
+        except Exception as ex:
+            clog().debug(
+                "Call to close() on interpreter failed (may happen): %s.",
+                str(ex)
+            )
+
         time.sleep(0.001)
-        self._interpreter.terminate(force=True)
+        try:
+            self._interpreter.terminate(force=True)
+        except Exception as ex:
+            clog().debug(
+                "Call to terminate() on interpreter failed (may happen): %s.",
+                str(ex)
+            )
+
+        time.sleep(0.001)
+        if self._interpreter.isalive():
+            who = tohuman(
+                self.language
+                if hasattr(self, 'language') and self.language else self
+            )
+            clog().warn(
+                "Incomplete '%s' Runner shutdown: too slow and it is still running.",
+                who
+            )
 
     @profile
     def _exec_and_wait(self, source, options, *, from_example=None, **kargs):


### PR DESCRIPTION
A close() may fail if the runner closed due the previous sent EOF; a
terminate() may fail if the runner closed due the previous close() call.

In both cases, log a debug message but call the two things
unconditionally.

If the runner is still alive, log a warning. It could be an error
however the problem is more likely to be a timing issue where the
runner is shutting down (too slow).

If we have _shutdown_interpreter to run in background we could change
the impl to do a more synchronous wait without introducing a noticeable
delay.

Closes #129 