### PR TITLE
Issue-177: capture env variables and put them in the clipboard

### DIFF
--- a/byexample/cmdline.py
+++ b/byexample/cmdline.py
@@ -258,6 +258,18 @@ def parse_args(args=None):
         default=[],
         help='skip these files'
     )
+    g.add_argument(
+        "--capture-env-var",
+        "--capture-env-vars",
+        action=_CSV,
+        metavar='<var names>',
+        default=[],
+        dest='captured_env_vars',
+        help='capture some environment variables and put them in ' + \
+             'the clipboard so they can be pasted and used in ' + \
+             'conditional executions. ' + \
+             'Comma separated syntax is also accepted.'
+    )
 
     g = parser.add_argument_group("Diff Options")
     g.add_argument(
@@ -439,14 +451,14 @@ def parse_args(args=None):
     # Some extra checks
     # -----------------
 
-    # the languages must be uniq
-    copy = set(namespace.languages)  # copy of uniqs
+    # the languages must be unique
+    copy = set(namespace.languages)  # copy of unique languages
     for l in namespace.languages:
         if l not in copy:
             parser.error("argument --languages: '%s' is duplicated." % l)
         copy.remove(l)
 
-    # the shebangs must belong to a language and must be uniq
+    # the shebangs must belong to a language and must be unique
     copy = set(k for k, v in namespace.shebangs)
     for k in (k for k, v in namespace.shebangs):
         if k not in copy:
@@ -457,7 +469,7 @@ def parse_args(args=None):
 
     namespace.shebangs = dict(namespace.shebangs)
 
-    # the log masks must be uniq and the levels must be known
+    # the log masks must be unique and the levels must be known
     copy = set(k for k, v in namespace.log_masks)
     for k, v in namespace.log_masks:
         if k not in copy:
@@ -486,6 +498,15 @@ def parse_args(args=None):
     namespace.testfiles = list(
         sorted(f for f in namespace.files if f in allowed)
     )
+
+    # the captured environment variables must be unique
+    copy = set(namespace.captured_env_vars)
+    for k in namespace.captured_env_vars:
+        if k not in copy:
+            parser.error(
+                "argument --captured-env-vars: '%s' is duplicated." % k
+            )
+        copy.remove(k)
 
     # Do not spawn more jobs than testfiles
     namespace.jobs = min(namespace.jobs, len(namespace.testfiles))

--- a/byexample/init.py
+++ b/byexample/init.py
@@ -380,6 +380,7 @@ def get_options(args, cfg):
             'interact': False,
             'shebangs': args.shebangs,
             'difftool': args.difftool,
+            'captured_env_vars': args.captured_env_vars,
         }
     )
     clog().chat("Options (cmdline): %s", options)

--- a/docs/_includes/idx.html
+++ b/docs/_includes/idx.html
@@ -30,6 +30,7 @@
     <li><a href="/{{ site.uprefix }}/advanced/terminal-emulation">Terminal emulation</a></li>
     <li><a href="/{{ site.uprefix }}/advanced/unicode">Unicode support</a></li>
     <li><a href="/{{ site.uprefix }}/advanced/conditional-execution">Conditional execution</a></li>
+    <li><a href="/{{ site.uprefix }}/advanced/capture-environment-variables">Capture environment variables</a></li>
     <li><a href="/{{ site.uprefix }}/advanced/echo-filtering">Echo filtering</a></li>
     <li><a href="/{{ site.uprefix }}/advanced/troubleshooting">Troubleshooting</a></li>
 </ul>

--- a/docs/advanced/capture-environment-variables.md
+++ b/docs/advanced/capture-environment-variables.md
@@ -1,0 +1,111 @@
+<!--
+Check that we have byexample installed first
+$ hash byexample                                    # byexample: +fail-fast
+
+$ alias byexample=byexample\ --pretty\ none
+
+--
+-->
+
+# Environment Variables
+
+`byexample` passes the environment variables to the
+interpreters and they are available from the examples and modules.
+
+This is the default and quite handy if you want to make your
+documentation *configurable* for *scripting*.
+
+Let's say you have a [shell](/{{ site.uprefix }}/languages/shell.md)
+example:
+
+```shell
+$ if [ "$PWD" != "/root" ]; then
+>   echo "You must run this script from /root"
+> fi
+You must run this script from /root
+```
+
+
+## Pasting a captured environment variable
+
+But what if we want to *capture* their value and
+[paste them](/{{ site.uprefix }}/basic/capture-and-paste.md) as part of
+an example?
+
+Consider an example where a Python example *depends* on the current
+directory.
+
+Because you could be running `byexample` from *anywhere*, such example
+would likely fail: the output is not deterministic.
+
+However you could [paste](/{{ site.uprefix
+}}/basic/capture-and-paste.md) the environment variable `$PWD` which has
+the current directory as the expected output.
+
+```shell
+$ cat test/ds/capture-env.doc               # byexample: +rm=  -tags
+    >>> import os
+    >>> assert '<PWD>' == os.getcwd()    # byexample: +paste
+```
+
+You just need to pass which variables from the environment will be in
+the clipboard of `byexample` so they can be pasted.
+
+```shell
+$ byexample -l python --capture-env-var PWD test/ds/capture-env.doc
+<...>
+[PASS] Pass: 2 Fail: 0 Skip: 0
+```
+
+You can capture as many environment variables as you want:
+
+```shell
+$ byexample -l python --capture-env-vars PWD,HOME,USER test/ds/capture-env.doc
+<...>
+[PASS] Pass: 2 Fail: 0 Skip: 0
+```
+
+## Conditional execution on a captured environment variable
+
+Perhaps the most useful combination is with
+[conditionals](/{{site.uprefix }}/advanced/conditional-execution.md).
+
+Consider the following toy-example that it is executed *unless* the
+given environment variable is passed:
+
+```shell
+$ cat test/ds/capture-bomb.doc               # byexample: +rm= 
+    $ echo "Booom!"    # byexample: +unless=bomb_disabled
+    The bomb should not explode!
+```
+
+Running the example with an empty or unset variable `bomb_disabled` will
+make the example to run and fail (as expected, the bomb exploded).
+
+```shell
+$ echo $bomb_disabled  # empty, it is not set
+$ byexample -l shell --capture-env-var bomb_disabled test/ds/capture-bomb.doc
+<...>
+Expected:
+The bomb should not explode!
+Got:
+Booom!
+<...>
+[FAIL] Pass: 0 Fail: 1 Skip: 0
+```
+
+But setting anything to the variable we can *skip* the execution of the
+example.
+
+```shell
+$ export bomb_disabled=some
+$ byexample -l shell --capture-env-var bomb_disabled test/ds/capture-bomb.doc
+<...>
+[PASS] Pass: 0 Fail: 0 Skip: 1
+```
+
+> **Note:** in both cases `bomb_disabled` was put in the clipboard, this
+> is required because `+unless` will complain if the variable is not
+> there (empty or not empty).
+
+> *New* in ``byexample 10.1.0``. This feature is marked as ``experimental``.

--- a/docs/overview/usage.md
+++ b/docs/overview/usage.md
@@ -91,11 +91,11 @@ capabilities
 ```
 $ byexample -h                                # byexample: +norm-ws -tags +rm=  +diff=ndiff
 usage: byexample -l <languages> [--ff] [--timeout <secs>] [-j <n>] [--dry]
-                 [--skip <file> [<file> ...]]
+                 [--skip <file> [<file> ...]] [--capture-env-var <var names>]
                  [-d {none,unified,ndiff,context,tool}] [--difftool <cmd>]
                  [--no-enhance-diff] [-o <options>] [--show-options]
-                 [-m <dir>] [--encoding <enc>] [--show-failures <n>] [--pretty {none,all}] [-V]
-                 [-v | -q] [-h | -xh]
+                 [-m <dir>] [--encoding <enc>] [--show-failures <n>]
+                 [--pretty {none,all}] [-V] [-v | -q] [-h | -xh]
  
 Write snippets of code in C++, Python, Ruby, and others as documentation and
 execute them as regression tests.
@@ -120,6 +120,11 @@ Execution Options:
   --dry                 do not run any example, only parse them.
   --skip <file> [<file> ...]
                         skip these files
+  --capture-env-var <var names>, --capture-env-vars <var names>
+                        capture some environment variables and put them in the
+                        clipboard so they can be pasted and used in
+                        conditional executions. Comma separated syntax is also
+                        accepted.
  
 Diff Options:
   -d {none,unified,ndiff,context,tool}, --diff {none,unified,ndiff,context,tool}

--- a/test/ds/capture-bomb.doc
+++ b/test/ds/capture-bomb.doc
@@ -1,0 +1,2 @@
+$ echo "Booom!"    # byexample: +unless=bomb_disabled
+The bomb should not explode!

--- a/test/ds/capture-env.doc
+++ b/test/ds/capture-env.doc
@@ -1,0 +1,2 @@
+>>> import os
+>>> assert '<PWD>' == os.getcwd()    # byexample: +paste


### PR DESCRIPTION
Add a command line argument to capture environment variables and put
them into the clipboard so they can be pasted and used in conditionals.

This capture is done per worker and preserved. Modifications to the
environment will not be reflected on purpose.

Closes #177