### PR TITLE
use collections.abc

### DIFF
--- a/byexample/cfg.py
+++ b/byexample/cfg.py
@@ -1,9 +1,10 @@
 from __future__ import unicode_literals
 from .common import transfer_constants
 import collections
+import collections.abc
 
 
-class Config(collections.Mapping):
+class Config(collections.abc.Mapping):
     ''' An immutable configuration object.
 
         Once the configuration was loaded, this object should be

--- a/byexample/init.py
+++ b/byexample/init.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-import sys, pkgutil, inspect, pprint, os, collections, operator
+import sys, pkgutil, inspect, pprint, os, operator
 
 from itertools import chain as chain_iters
 

--- a/byexample/options.py
+++ b/byexample/options.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
-import collections, argparse, shlex, pprint, sys
+import collections.abc, argparse, shlex, pprint, sys
 
 
-class Options(collections.MutableMapping):
+class Options(collections.abc.MutableMapping):
     r'''
     The execution of the examples can be modified by configuring different options.
 


### PR DESCRIPTION
MutableMapping has been removed from collections in Python 3.10.

(this was deprecated since Python 3.3 apparently)