### PR TITLE
Fix self.input_list iteration on example print (verbose)

### DIFF
--- a/byexample/example.py
+++ b/byexample/example.py
@@ -174,7 +174,7 @@ class Example(object):
         )
 
         inputs = []
-        for prefix, inp in self.input_list:
+        for prefix, prefix_regex, inp in self.input_list:
             n = len(inp)
             if n > 14:  # 12 max bytes plus 2 dots
                 inp = inp[:6] + '..' + inp[-6:]


### PR DESCRIPTION
The self.input_list changed from a 2-tuple list to a 3-tuple list quite
along but this code was never properly tested and it failed only in a
very verbose mode and even on that, the error never stopped byexample
(which it is good from user's perspective but not so good for byexample
developers': this just hides the real bug).

Fix but leave the test for another PR.