### PR TITLE
Print byexample pkg location and paths and dependencies' versions (-V)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ exec(open(path.join(here, 'byexample', '__init__.py')).read())
 
 # the following are the required dependencies
 # without them, we cannot run byexample
+# NOTE: keep this list in sync with byexample/cmdline.py
 required_deps=[
     'pexpect>=4,<5',     # pexpect 4.x.x required
     'appdirs>=1.4.3,<2', # appdirs 1.4.x (x >= 3) required
@@ -48,6 +49,7 @@ required_deps=[
 # these, on the other hand, are optional nice to have
 # dependencies. we'll install them by default but if they
 # are not present, byexample will run normally.
+# NOTE: keep this list in sync with byexample/cmdline.py
 nice_to_have_deps=[
     'tqdm>=4,<5',     # tqdm 4.x.x required
     'pygments>=2,<3', # pygments 2.x.x required

--- a/test/corner_cases.md
+++ b/test/corner_cases.md
@@ -158,3 +158,27 @@ proving that calling code in background is possible.
 $ byexample -m test/ds/submod -l python -q test/ds/one.md
 ---> 42 bg
 ```
+
+## License, dependencies' versions and `byexample` package location
+
+```shell
+$ byexample -V                                  # byexample: +norm-ws
+byexample <...> (Python <...>) - GNU GPLv3
+Write snippets of code in C++, Python, Ruby, and others as documentation
+and execute them as regression tests.
+Copyright (C) Di Paola Martin - https://byexamples.github.io
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+Location: /<...>/byexample
+Package paths: /<...>/byexample
+Dependencies: appdirs (<...>), bracex (<...>), pexpect (<...>),
+pygments (<...>), pyte (<...>), tqdm (<...>)
+```


### PR DESCRIPTION
For introspection and better debugging info, print the package location
(__file__) and the package paths (__path__) of byexample when -V
(--version) is given.

Also, print all the 3rd parties dependencies and its versions. This does
not include neither 3rd parties modules nor runner/interpreter versions.