### PR TITLE
Explain a possible fix for the argparse limitation with --options

### DIFF
--- a/byexample/cmdline.py
+++ b/byexample/cmdline.py
@@ -316,6 +316,16 @@ class ByexampleArgumentParser(argparse.ArgumentParser):
 
         return [arg_line]
 
+    def error(self, msg):
+        if '/--options:' in msg:
+            msg += "\nIf you wrote --options -foo, try put an equal like --options=-foo"
+            msg += "\nand use quotes if you want to set multiples options like --options='-foo +bar'"
+
+        # note: this self.error method must never return: or
+        # we exit the program, or we raise an exception or we
+        # call our parent's error method that will not return.
+        argparse.ArgumentParser.error(self, msg)
+
 
 @profile
 def parse_args(args=None):

--- a/docs/basic/options.md
+++ b/docs/basic/options.md
@@ -31,6 +31,39 @@ File test/ds/python-tutorial.v2.md, 4/4 test ran in <...> seconds
 [PASS] Pass: 4 Fail: 0 Skip: 0
 ```
 
+If the option begins with `-`, `byexample` may get confuse and it will
+complain that no argument was given to `--options`:
+
+```shell
+$ byexample -l python -o -warn-tab test/ds/example-with-tabs-in-code.md
+<...>
+byexample: error: argument -o/--options: expected one argument
+If you wrote --options -foo, try put an equal like --options=-foo
+and use quotes if you want to set multiples options like --options='-foo +bar'
+```
+
+The error is because `byexample` presumes that `-warn-tab` is another
+command line flag like `-l` and `-o` and not the argument for `-o`.
+
+As the error message suggests you can workaround this *joining* `-o`
+with its argument with an `=`:
+
+```shell
+$ byexample -l python -o=-warn-tab test/ds/example-with-tabs-in-code.md
+<...>
+File test/ds/example-with-tabs-in-code.md, <...>
+[PASS] Pass: 1 Fail: 0 Skip: 0
+```
+
+If you need to pass multiple options to `-o` you can quote them together:
+
+```shell
+$ byexample -l python -o='-warn-tab +norm-ws' test/ds/example-with-tabs-in-code.md
+<...>
+File test/ds/example-with-tabs-in-code.md, <...>
+[PASS] Pass: 1 Fail: 0 Skip: 0
+```
+
 ## Show all the options
 
 You can know what options are available for a given language running the help

--- a/docs/overview/faq.md
+++ b/docs/overview/faq.md
@@ -367,9 +367,48 @@ If you are sure that you want a tab in the code you can disable the
 warning adding `-warn-tab` in the example or from the command line:
 
 ```shell
-$ byexample -l python -o '+ -warn-tab' test/ds/example-with-tabs-in-code.md
+$ byexample -l python -o=-warn-tab test/ds/example-with-tabs-in-code.md
 <...>
 File test/ds/example-with-tabs-in-code.md, <...>
 [PASS] Pass: 1 Fail: 0 Skip: 0
 ```
 
+### `byexample` fails with `argument -o/--options: expected one argument`
+
+The `-o` or `--options` expects a single argument, a string with the
+[options to set](/{{ site.uprefix }}/basic/options).
+
+You may forgot to pass it.
+
+But probably is not the case, isn't? You may be passing an argument
+like:
+
+```shell
+$ byexample -l python -o -warn-tab test/ds/example-with-tabs-in-code.md
+<...>
+byexample: error: argument -o/--options: expected one argument
+If you wrote --options -foo, try put an equal like --options=-foo
+and use quotes if you want to set multiples options like --options='-foo +bar'
+```
+
+The error is because `byexample` presumes that `-warn-tab` is another
+command line flag like `-l` and `-o` and not the argument for `-o`.
+
+As the error message suggests you can workaround this *joining* `-o`
+with its argument with an `=`:
+
+```shell
+$ byexample -l python -o=-warn-tab test/ds/example-with-tabs-in-code.md
+<...>
+File test/ds/example-with-tabs-in-code.md, <...>
+[PASS] Pass: 1 Fail: 0 Skip: 0
+```
+
+If you need to pass multiple options to `-o` you can quote them together:
+
+```shell
+$ byexample -l python -o='-warn-tab +norm-ws' test/ds/example-with-tabs-in-code.md
+<...>
+File test/ds/example-with-tabs-in-code.md, <...>
+[PASS] Pass: 1 Fail: 0 Skip: 0
+```

--- a/docs/recipes/python-doctest.md
+++ b/docs/recipes/python-doctest.md
@@ -166,7 +166,7 @@ has some ellipsis.
 The following is what `doctest` outputs. Can you spot where is the difference?
 
 ```shell
-$ python -m doctest -o REPORT_NDIFF  test/ds/doctest-hard-diff.md	# byexample: +tags
+$ python -m doctest -o REPORT_NDIFF  test/ds/doctest-hard-diff.md       # byexample: +tags
 <...>
 Differences (ndiff with -expected +actual):
     - {'debugger-id': ...


### PR DESCRIPTION
argparse, currently, cannot handle values for options that start with -
which also identifies other options.

So --options -foo is seen as 2 argument-less options and because
--options requires 1 argument, argparse fails.

The solution is stick the option with its argument as in --options=-foo

This commits suggests the user to do that.

Closes #31 