### PR TITLE
fix: unset PAGER, LESS, PROMPT_COMMAND env vars in Shell

### DIFF
--- a/byexample/modules/shell.py
+++ b/byexample/modules/shell.py
@@ -130,7 +130,7 @@ class ShellInterpreter(ExampleRunner, PexpectMixin):
 
     def get_default_cmd(self, *args, **kargs):
         shell = kargs.pop('shell', 'bash')
-        return "%e -u PS1 -u PS2 %p %a", {
+        return "%e -u PS1 -u PS2 -u PAGER -u LESS -u PROMPT_COMMAND %p %a", {
             'bash': {
                 'e': '/usr/bin/env',
                 'p': 'bash',
@@ -158,7 +158,7 @@ class ShellInterpreter(ExampleRunner, PexpectMixin):
         if shell in ('dash', 'sh'):
             return None
 
-        return "%e %p %a", {
+        return "%e -u PS1 -u PS2 -u PAGER -u LESS -u PROMPT_COMMAND  %p %a", {
             'bash': {
                 'e': '/usr/bin/env',
                 'p': 'bash',


### PR DESCRIPTION
This shell variable may interfere with the examples as they are executed quite often and they are probably tweaked by the user for his/her shell and not for byexample's shell.

Because we are not loading any rc or profile file, it is unlikely that these variables are set in a byexample shell session however it is better to be sure.

Closes #269 